### PR TITLE
Fix segments count query

### DIFF
--- a/squid-blockexplorer/src/blocks/index.ts
+++ b/squid-blockexplorer/src/blocks/index.ts
@@ -4,7 +4,6 @@ import {
   getHistorySizeFactory,
   getSpacePledgedFactory,
   solutionRangesStorageFactory,
-  historySizeStorageFactory,
 } from './storage';
 import { getOrCreateAccountFactory, processCalls, processExtrinsicsFactory } from './processCalls';
 import { processEvents, } from './processEvents';
@@ -12,7 +11,7 @@ export { processBlocksFactory } from "./processBlocks";
 
 export function createProcessBlocksDependencies(ctx: Context): ProcessBlocksDependencies {
   const getSpacePledged = getSpacePledgedFactory(ctx, solutionRangesStorageFactory);
-  const getHistorySize = getHistorySizeFactory(ctx, historySizeStorageFactory);
+  const getHistorySize = getHistorySizeFactory(ctx);
   const getOrCreateAccount = getOrCreateAccountFactory(ctx);
   const processExtrinsics = processExtrinsicsFactory(getOrCreateAccount);
 

--- a/squid-blockexplorer/src/blocks/storage.ts
+++ b/squid-blockexplorer/src/blocks/storage.ts
@@ -1,7 +1,7 @@
 import { SubstrateBlock } from '@subsquid/substrate-processor';
 import { Context } from '../processor';
 import { SubspaceRecordsRootStorage, SubspaceSolutionRangesStorage } from '../types/storage';
-import { calcHistorySize, calcSpacePledged } from './utils';
+import { calcHistorySize, calcSpacePledged, getStorageHash } from './utils';
 
 export function solutionRangesStorageFactory(ctx: Context, header: SubstrateBlock) {
   return new SubspaceSolutionRangesStorage(ctx, header);
@@ -19,10 +19,14 @@ export function getSpacePledgedFactory(ctx: Context, storageFactory: (ctx: Conte
   }
 }
 
-export function getHistorySizeFactory(ctx: Context, storageFactory: (ctx: Context, header: SubstrateBlock) => SubspaceRecordsRootStorage) {
+export function getHistorySizeFactory(ctx: Context) {
   return async function getHistorySize(header: SubstrateBlock) {
-    const storage = storageFactory(ctx, header);
-    const segmentsCount = (await storage.getAllAsV3()).length;
+    const storageHash = getStorageHash('Subspace', 'RecordsRoot');
+    // SubspaceRecordsRoot is a hash map and we need a count of items (segments)
+    // SubspaceRecordsRootStorage generated type unfortunately does not provide method to get count, 
+    // it has getAllAsV3 method, which returns all items and is too expensive,
+    // instead we're querying state using client.call API
+    const segmentsCount = (await ctx._chain.client.call('state_getKeys', [storageHash, header.hash])).length;
     return calcHistorySize(segmentsCount);
   }
 }

--- a/squid-blockexplorer/src/blocks/utils.ts
+++ b/squid-blockexplorer/src/blocks/utils.ts
@@ -1,3 +1,5 @@
+import { HexSink } from "@subsquid/scale-codec";
+import { xxhash128 } from "@subsquid/util-xxhash";
 import { SubstrateBlock } from '@subsquid/substrate-processor';
 import { Block, Extrinsic, Call, Account } from '../model';
 import { CallItem, EventItem } from "../processor";
@@ -93,4 +95,27 @@ export function calcHistorySize(segmentsCount: number): bigint {
   const SEGMENT_SIZE = RECORDED_HISTORY_SEGMENT_SIZE / RECORD_SIZE * PIECE_SIZE * 2;
 
   return BigInt(segmentsCount * SEGMENT_SIZE);
+}
+
+/**
+ * Converts string into Scale-encoded hash
+ * @param {string} name
+ * @return {string} - hex result
+ */
+function getNameHash(name: string): string {
+  const digest = xxhash128().update(name).digest();
+  const sink = new HexSink();
+  sink.u128(digest);
+  const hash = sink.toHex();
+  return hash;
+}
+
+/**
+ * Converts prefix and name into Scale-encoded hash, useful for querying storage
+ * @param {string} prefix - pallet name (i.e "Subspace")
+ * @param {string} name - storage name (i.e. "RecordsRoot")
+ * @return {string} - hex result
+ */
+export function getStorageHash(prefix: string, name: string) {
+  return getNameHash(prefix) + getNameHash(name).slice(2);
 }

--- a/squid-blockexplorer/src/mocks/mocks.ts
+++ b/squid-blockexplorer/src/mocks/mocks.ts
@@ -142,6 +142,12 @@ const chainMock = {
   },
   getConstant(): any {
     return;
+  },
+  // at the moment we only use client.call to query segments count at blocks/storage.ts
+  client: {
+    call() {
+      return new Array(SEGMENTS_COUNT);
+    }
   }
 } as unknown as Chain;
 

--- a/squid-blockexplorer/src/test/blocks/storage.test.ts
+++ b/squid-blockexplorer/src/test/blocks/storage.test.ts
@@ -5,7 +5,6 @@ import { calcSpacePledged, calcHistorySize } from '../../blocks/utils';
 import {
   contextMock,
   solutionRangesStorageFactoryMock,
-  historySizeStorageFactoryMock,
   SOLUTION_RANGES,
   SEGMENTS_COUNT,
 } from '../../mocks/mocks';
@@ -40,7 +39,7 @@ tap.test('getSpacePledgedFactory should create getSpacePledged method, which ret
 });
 
 tap.test('getHistorySizeFactory should create getHistorySize method, which returns history size (bigint)', async (t) => {
-  const getHistorySize = getHistorySizeFactory(contextMock, historySizeStorageFactoryMock);
+  const getHistorySize = getHistorySizeFactory(contextMock);
 
   const result = await getHistorySize(BlockHeaderMock);
   const expected = calcHistorySize(SEGMENTS_COUNT);


### PR DESCRIPTION
Fix for the bug we have due to a big response size when querying segments from the storage (in order to calculate blockchain history size). Instead of querying all items from the storage, we're querying only hash map keys to get the items count