### PR TITLE
Fix hash router

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -24,7 +24,7 @@ import 'swiper/css'
 
 function App() {
   return (
-    <HashRouter basename={`${process.env.REACT_APP_PUBLIC_URL}`}>
+    <HashRouter>
       <Layout>
         <Header />
         <Container>


### PR DESCRIPTION
Probably we don't need `basename` anymore. Netlify works without it, also previous PR broke GH pages version, I hope removing it will fix