### PR TITLE
Replace `ctx.store.save` by `ctx.store.insert`

### DIFF
--- a/squid-blockexplorer/src/blocks/processBlocks.ts
+++ b/squid-blockexplorer/src/blocks/processBlocks.ts
@@ -41,11 +41,11 @@ export function processBlocksFactory({
     }
 
     // saving results
-    await ctx.store.save(blocks);
-    await ctx.store.save([...extrinsicsMap.values()]);
-    await ctx.store.save([...callsMap.values()]);
-    await ctx.store.save(events);
-    await ctx.store.save(logs);
+    await ctx.store.insert(blocks);
+    await ctx.store.insert([...extrinsicsMap.values()]);
+    await ctx.store.insert([...callsMap.values()]);
+    await ctx.store.insert(events);
+    await ctx.store.insert(logs);
 
     ctx.log
       .child('blocks')

--- a/squid-blockexplorer/src/test/blocks/processBlocks.test.ts
+++ b/squid-blockexplorer/src/test/blocks/processBlocks.test.ts
@@ -47,11 +47,11 @@ tap.test('processBlocks should process blocks and items from the Context and sav
     blocks,
   } as Context;
 
-  const saveSpy = sinon.spy(context.store, 'save');
+  const saveSpy = sinon.spy(context.store, 'insert');
 
   await processBlocks(context);
 
-  // expect store.save method calls: blocks, extrinsics, calls, events, logs
+  // expect store.insert method calls: blocks, extrinsics, calls, events, logs
   t.equal(saveSpy.callCount, 5);
 
   // check stored block ids against block ids in the context


### PR DESCRIPTION
Currently, we have slow queries when inserting calls, events, and logs. Unlike `save`, `insert` method supports batching if there are more than 1000 items. 
