### PR TITLE
Add block items counts

### DIFF
--- a/squid-blockexplorer/db/migrations/1671352686402-Data.js
+++ b/squid-blockexplorer/db/migrations/1671352686402-Data.js
@@ -1,5 +1,5 @@
-module.exports = class Data1671003885652 {
-    name = 'Data1671003885652'
+module.exports = class Data1671352686402 {
+    name = 'Data1671352686402'
 
     async up(db) {
         await db.query(`CREATE TABLE "call" ("id" character varying NOT NULL, "name" text NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "success" boolean NOT NULL, "args" jsonb, "error" jsonb, "signer" text, "pos" integer, "block_id" character varying, "extrinsic_id" character varying, "parent_id" character varying, CONSTRAINT "PK_2098af0169792a34f9cfdd39c47" PRIMARY KEY ("id"))`)
@@ -12,7 +12,7 @@ module.exports = class Data1671003885652 {
         await db.query(`CREATE INDEX "IDX_83cf1bd59aa4521ed882fa5145" ON "event" ("call_id") `)
         await db.query(`CREATE TABLE "log" ("id" character varying NOT NULL, "kind" text NOT NULL, "value" jsonb, "block_id" character varying, CONSTRAINT "PK_350604cbdf991d5930d9e618fbd" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_7d3f5ac68148194ee7ced3032e" ON "log" ("block_id") `)
-        await db.query(`CREATE TABLE "block" ("id" character varying NOT NULL, "height" numeric NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "hash" text NOT NULL, "parent_hash" text NOT NULL, "spec_id" text NOT NULL, "state_root" text NOT NULL, "extrinsic_root" text, "space_pledged" numeric NOT NULL, "blockchain_size" numeric NOT NULL, CONSTRAINT "PK_d0925763efb591c2e2ffb267572" PRIMARY KEY ("id"))`)
+        await db.query(`CREATE TABLE "block" ("id" character varying NOT NULL, "height" numeric NOT NULL, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "hash" text NOT NULL, "parent_hash" text NOT NULL, "spec_id" text NOT NULL, "state_root" text NOT NULL, "extrinsic_root" text, "space_pledged" numeric NOT NULL, "blockchain_size" numeric NOT NULL, "extrinsics_count" integer NOT NULL, "events_count" integer NOT NULL, CONSTRAINT "PK_d0925763efb591c2e2ffb267572" PRIMARY KEY ("id"))`)
         await db.query(`CREATE INDEX "IDX_bce676e2b005104ccb768495db" ON "block" ("height") `)
         await db.query(`CREATE TABLE "extrinsic" ("id" character varying NOT NULL, "hash" text NOT NULL, "index_in_block" integer NOT NULL, "nonce" numeric, "name" text NOT NULL, "signature" text, "error" jsonb, "tip" numeric, "fee" numeric, "success" boolean NOT NULL, "pos" integer, "timestamp" TIMESTAMP WITH TIME ZONE NOT NULL, "args" jsonb, "signer_id" character varying, "block_id" character varying, CONSTRAINT "PK_80d7db0e4b1e83e30336bc76755" PRIMARY KEY ("id"))`)
         await db.query(`CREATE UNIQUE INDEX "IDX_1f45de0713a55049009e8e8127" ON "extrinsic" ("hash") `)

--- a/squid-blockexplorer/schema.graphql
+++ b/squid-blockexplorer/schema.graphql
@@ -22,6 +22,8 @@ type Block @entity {
   logs: [Log!]! @derivedFrom(field: "block") @cardinality(value: 1000)
   spacePledged: BigInt!
   blockchainSize: BigInt!
+  extrinsicsCount: Int!
+  eventsCount: Int!
 }
 
 type Extrinsic @entity {

--- a/squid-blockexplorer/src/blocks/utils.ts
+++ b/squid-blockexplorer/src/blocks/utils.ts
@@ -27,18 +27,29 @@ export function partitionItems<Item = CallItem | EventItem>(
   return partitioned;
 }
 
+interface CreateBlockParams {
+  header: SubstrateBlock;
+  spacePledged: bigint;
+  blockchainSize: bigint;
+  extrinsicsCount: number;
+  eventsCount: number;
+}
 
-export function createBlock(
-  header: SubstrateBlock,
-  spacePledged: bigint,
-  blockchainSize: bigint
-) {
+export function createBlock({
+  header,
+  spacePledged,
+  blockchainSize,
+  extrinsicsCount,
+  eventsCount,
+}: CreateBlockParams) {
   return new Block({
     ...header,
     height: BigInt(header.height),
     timestamp: new Date(header.timestamp),
     spacePledged,
     blockchainSize,
+    extrinsicsCount,
+    eventsCount,
   });
 }
 

--- a/squid-blockexplorer/src/mocks/mocks.ts
+++ b/squid-blockexplorer/src/mocks/mocks.ts
@@ -199,7 +199,13 @@ export const digestStorageFactoryMock = () => ({
 
 export const getOrCreateAccountMock = () => Promise.resolve(new Account({ id: 'random account id' }));
 
-export const blockMock = createBlock(BlockHeaderMock, BigInt(1), BigInt(2));
+export const blockMock = createBlock({
+  header: BlockHeaderMock, 
+  spacePledged: BigInt(1), 
+  blockchainSize: BigInt(2),
+  extrinsicsCount: 2,
+  eventsCount: 5,
+});
 export const extrinsicMock = createExtrinsic(parentCallItem as CallItem, blockMock);
 export const parentCallMock = createCall(parentCallItem as CallItem, blockMock, extrinsicMock, null);
 

--- a/squid-blockexplorer/src/model/generated/block.model.ts
+++ b/squid-blockexplorer/src/model/generated/block.model.ts
@@ -53,4 +53,10 @@ export class Block {
 
     @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})
     blockchainSize!: bigint
+
+    @Column_("int4", {nullable: false})
+    extrinsicsCount!: number
+
+    @Column_("int4", {nullable: false})
+    eventsCount!: number
 }

--- a/squid-blockexplorer/src/test/blocks/utils.test.ts
+++ b/squid-blockexplorer/src/test/blocks/utils.test.ts
@@ -8,7 +8,13 @@ const spacePledged = BigInt(1);
 const blockchainSize = BigInt(2);
 
 tap.test('createBlock should create instance of a Block', (t) => {
-  const result = createBlock(BlockHeaderMock, spacePledged, blockchainSize);
+  const result = createBlock({
+    header: BlockHeaderMock, 
+    spacePledged, 
+    blockchainSize,
+    extrinsicsCount: 2,
+    eventsCount: 5,
+  });
 
   t.type(result, Block);
   t.has(result, {
@@ -26,7 +32,13 @@ tap.test('createBlock should create instance of a Block', (t) => {
 });
 
 tap.test('createCall should create instance of Call without parent Call', (t) => {
-  const block = createBlock(BlockHeaderMock, spacePledged, blockchainSize);
+  const block = createBlock({
+    header: BlockHeaderMock, 
+    spacePledged, 
+    blockchainSize,
+    extrinsicsCount: 2,
+    eventsCount: 5,
+  });
   const extrinsic = createExtrinsic(callItemWithSignature, block, null, null);
   const result = createCall(callItemWithSignature, block, extrinsic, null);
   t.type(result, Call);
@@ -36,7 +48,13 @@ tap.test('createCall should create instance of Call without parent Call', (t) =>
 tap.todo('createCall should create instance of Call with parent Call');
 
 tap.test('createExtrinsic should create instance of Extrinsic without signature', (t) => {
-  const block = createBlock(BlockHeaderMock, spacePledged, blockchainSize);
+  const block = createBlock({
+    header: BlockHeaderMock, 
+    spacePledged, 
+    blockchainSize,
+    extrinsicsCount: 2,
+    eventsCount: 5,
+  });
   const result = createExtrinsic(callItemWithSignature, block, null, null);
 
   t.type(result, Extrinsic);


### PR DESCRIPTION
Related to #87

Update Graphql schema - block now includes `extrinsicsCount` and `eventsCount` (won't have to query all extrinsics and events to calculate their count on the client)

Separate PR for the frontend will come next.