### PR TITLE
Remove `REACT_APP_GRAPHQL_API_URL` env variable

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,5 +34,3 @@ jobs:
           yarn lint:fix
       - name: Build project 🔧
         run: yarn build
-        env:
-          REACT_APP_GRAPHQL_API_URL: ${{secrets.REACT_APP_GRAPHQL_API_URL}}

--- a/.github/workflows/gh-deploy-main.yml
+++ b/.github/workflows/gh-deploy-main.yml
@@ -21,7 +21,6 @@ jobs:
           yarn install --frozen-lockfile
           yarn build
         env:
-          REACT_APP_GRAPHQL_API_URL: ${{secrets.REACT_APP_GRAPHQL_API_URL}}
           REACT_APP_PUBLIC_URL: ${{secrets.REACT_APP_PUBLIC_URL}}
 
       - name: Deploy 🚀

--- a/client/.env.sample
+++ b/client/.env.sample
@@ -1,2 +1,1 @@
-REACT_APP_GRAPHQL_API_URL="subsquid url"
 REACT_APP_PUBLIC_URL='/'

--- a/client/codegen.ts
+++ b/client/codegen.ts
@@ -1,11 +1,14 @@
 import * as dotenv from 'dotenv'
 import type { CodegenConfig } from '@graphql-codegen/cli'
 
+// domains
+import domains from './src/layout/config/domain.json'
+
 dotenv.config()
 
 const config: CodegenConfig = {
   overwrite: true,
-  schema: process.env.REACT_APP_GRAPHQL_API_URL,
+  schema: domains[0].urls.api,
   documents: './src/**/*.{ts,tsx}',
   generates: {
     './src/gql/': {

--- a/client/src/common/providers/DomainProvider.tsx
+++ b/client/src/common/providers/DomainProvider.tsx
@@ -1,9 +1,18 @@
 import { FC, useState, createContext, useContext, ReactNode } from 'react'
 import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client'
 
+// domains
+import domains from 'layout/config/domain.json'
+
 type Value = {
   domainApiAddress: string
   updateDomainAddress: (apiAddress: string) => void
+  domains: {
+    title: string
+    urls: {
+      api: string
+    }
+  }[]
 }
 
 const DomainContext = createContext<Value>(
@@ -16,7 +25,7 @@ type Props = {
 }
 
 export const DomainProvider: FC<Props> = ({ children }) => {
-  const [domainApiAddress, setDomainApiAddress] = useState(process.env.REACT_APP_GRAPHQL_API_URL)
+  const [domainApiAddress, setDomainApiAddress] = useState(domains[0].urls.api)
 
   const client = new ApolloClient({
     uri: domainApiAddress,
@@ -32,6 +41,7 @@ export const DomainProvider: FC<Props> = ({ children }) => {
       value={{
         updateDomainAddress: updateDomainAddress,
         domainApiAddress: domainApiAddress,
+        domains,
       }}
     >
       <ApolloProvider client={client}>{children}</ApolloProvider>
@@ -39,7 +49,7 @@ export const DomainProvider: FC<Props> = ({ children }) => {
   )
 }
 
-export const useDomain = (): Value => {
+export const useDomains = (): Value => {
   const context = useContext(DomainContext)
 
   if (!context) throw new Error('DomainContext must be used within DomainProvider')

--- a/client/src/layout/components/DomainHeader.tsx
+++ b/client/src/layout/components/DomainHeader.tsx
@@ -2,13 +2,10 @@ import { FC } from 'react'
 
 // common
 import { Tabs, Tab } from 'common/components'
-import { useDomain } from 'common/providers/DomainProvider'
-
-// domain
-import domains from 'layout/config/domain.json'
+import { useDomains } from 'common/providers/DomainProvider'
 
 const DomainHeader: FC = () => {
-  const { updateDomainAddress } = useDomain()
+  const { updateDomainAddress, domains } = useDomains()
 
   return (
     <div className='px-4 xl:px-0 z-10'>

--- a/client/typing.d.ts
+++ b/client/typing.d.ts
@@ -1,5 +1,5 @@
 declare namespace NodeJS {
   export interface ProcessEnv {
-    REACT_APP_GRAPHQL_API_URL: string
+    REACT_APP_PUBLIC_URL: string
   }
 }


### PR DESCRIPTION
No need to use this env var, since we already have urls in the `domain.json`