### PR TITLE
Minor processor refactoring

### DIFF
--- a/squid-blockexplorer/typegen.json
+++ b/squid-blockexplorer/typegen.json
@@ -1,6 +1,6 @@
 {
   "outDir": "src/types",
-  "specVersions": "http://68.183.67.157:8888/graphql",
+  "specVersions": "https://archive.gemini-3b.subspace.network/api",
   "constants": true,
   "events": true,
   "calls": true,


### PR DESCRIPTION
Move polkadot.js API instantiation outside of `processChain` function, because it is creating a new instance per block batch. 