### PR TITLE
Fix/site description

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Subspace Labs Testnetn Block Explorer"
+      content="Subspace Labs Gemini Block Explorer"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Subspace Labs Testnetn Block Explorer"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--


### PR DESCRIPTION
Replacing the current meta description in the head from `Web site created using create-react-app` with `Subspace Labs Gemini Block Explorer`