### PR TITLE
Update events processing

### DIFF
--- a/squid-blockexplorer/src/blocks/processEvents.ts
+++ b/squid-blockexplorer/src/blocks/processEvents.ts
@@ -23,15 +23,7 @@ export function processEventsFactory(getOrCreateAccount: (blockHeight: bigint, a
         call = callsMap.get(item.event.extrinsic.call.id);
       }
 
-      const genericEvent = new Event({
-        ...item.event,
-        block,
-        extrinsic,
-        call,
-        timestamp: block.timestamp,
-      });
-
-      // additional handling for reward events
+      // separate handling for reward events
       if (item.name === 'Rewards.BlockReward' || item.name === 'Rewards.VoteReward') {
         const address = item.event.args?.voter || item.event.args?.blockAuthor;
         const account = await getOrCreateAccount(block.height, address);
@@ -46,9 +38,17 @@ export function processEventsFactory(getOrCreateAccount: (blockHeight: bigint, a
         });
 
         rewardEvents.push(rewardEvent);
-      }
+      } else {
+        const genericEvent = new Event({
+          ...item.event,
+          block,
+          extrinsic,
+          call,
+          timestamp: block.timestamp,
+        });
 
-      events.push(genericEvent);
+        events.push(genericEvent);
+      }
     }
 
     return [events, rewardEvents];

--- a/squid-blockexplorer/src/test/blocks/processEvents.test.ts
+++ b/squid-blockexplorer/src/test/blocks/processEvents.test.ts
@@ -23,8 +23,8 @@ tap.test('processEvents should return a tuple including a list of Events and a l
   ];
 
   const [events, rewardEvents] = await processEvents(extrinsicsMap, callsMap, eventItems, blockMock);
-  t.equal(events.length, eventItems.length); // includes all events
-  t.equal(rewardEvents.length, 1); // only inludes reward events
+  t.equal(events.length, 1); // generic events
+  t.equal(rewardEvents.length, 1); // reward events
 
   t.end();
 });


### PR DESCRIPTION
Remove double processing of rewards (both as generic `Event` and `RewardEvent`) to reduce disk space consumption