### PR TITLE
Feat/add result table for conflicting event and extrinsic

### DIFF
--- a/client/src/common/helpers/formatSearchResult.ts
+++ b/client/src/common/helpers/formatSearchResult.ts
@@ -1,0 +1,25 @@
+import { Event, Extrinsic } from 'gql/graphql'
+
+export const formatSearchResult = (event: Event, extrinsic: Extrinsic) => {
+  const formattedExtrinsic = {
+    id: extrinsic.id,
+    blockHeight: extrinsic.block?.height,
+    indexInBlock: extrinsic.indexInBlock,
+    timestamp: extrinsic.timestamp,
+    action: extrinsic.name,
+    type: 'Extrinsic',
+  }
+
+  const formattedEvent = {
+    id: event.id,
+    blockHeight: event.block?.height,
+    indexInBlock: event.indexInBlock,
+    timestamp: event.timestamp,
+    action: event.name,
+    type: 'Event',
+  }
+
+  const formattedResult = [formattedExtrinsic, formattedEvent]
+
+  return formattedResult
+}

--- a/client/src/common/hooks/useSearch.ts
+++ b/client/src/common/hooks/useSearch.ts
@@ -9,6 +9,7 @@ import { INTERNAL_ROUTES } from 'common/routes'
 import useDomains from 'common/hooks/useDomains'
 import { formatAddress } from 'common/helpers/formatAddress'
 import { GET_RESULTS } from 'common/queries'
+import { formatSearchResult } from 'common/helpers/formatSearchResult'
 
 type Values = {
   handleSearch: (term: string, searchType: number) => void
@@ -45,11 +46,19 @@ const useSearch = (): Values => {
 
         if (data?.accountById) {
           navigate(INTERNAL_ROUTES.accounts.id.page(selectedChain.urls.page, term))
+        } else if (data?.extrinsicById && data?.eventById) {
+          const results = formatSearchResult(data.eventById, data.extrinsicById)
+          navigate(
+            INTERNAL_ROUTES.search.result.page(selectedChain.urls.page, 'extrinsicAndEvent'),
+            {
+              state: { results },
+            },
+          )
         } else if (data?.extrinsicById) {
           navigate(INTERNAL_ROUTES.extrinsics.id.page(selectedChain.urls.page, term))
         } else if (data?.extrinsics?.length > 0) {
           if (data.extrinsics.length > 1) {
-            navigate(INTERNAL_ROUTES.search.result.page(selectedChain.urls.page), {
+            navigate(INTERNAL_ROUTES.search.result.page(selectedChain.urls.page, 'extrinsics'), {
               state: { extrinsics: data.extrinsics },
             })
           } else {

--- a/client/src/common/queries/index.ts
+++ b/client/src/common/queries/index.ts
@@ -30,12 +30,24 @@ export const GET_RESULTS = gql`
     }
     extrinsicById(id: $term) @include(if: $isExtrinsic) {
       id
+      name
+      block {
+        height
+      }
+      indexInBlock
+      timestamp
     }
     extrinsics(limit: 1, where: { hash_eq: $term }) @include(if: $isExtrinsicHash) {
       id
     }
     eventById(id: $term) @include(if: $isEvent) {
       id
+      name
+      block {
+        height
+      }
+      indexInBlock
+      timestamp
     }
   }
 `

--- a/client/src/common/routes/index.ts
+++ b/client/src/common/routes/index.ts
@@ -58,8 +58,8 @@ export const INTERNAL_ROUTES = {
   },
   search: {
     result: {
-      path: 'search/result',
-      page: (chain: string): string => `/${chain}/search/result`,
+      path: 'search/result/:type',
+      page: (chain: string, type: string): string => `/${chain}/search/result/${type}`,
     },
   },
   notFound: '/404',

--- a/client/src/gql/index.ts
+++ b/client/src/gql/index.ts
@@ -1,2 +1,2 @@
-export * from "./gql"
-export * from "./fragment-masking"
+export * from './gql'
+export * from './fragment-masking'

--- a/client/src/layout/components/ExtrinsicAndEventResult/ExtrinsicAndEventResultCard.tsx
+++ b/client/src/layout/components/ExtrinsicAndEventResult/ExtrinsicAndEventResultCard.tsx
@@ -1,0 +1,49 @@
+import { FC } from 'react'
+import { Link } from 'react-router-dom'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+
+// layout
+import { Result } from 'layout/components/ExtrinsicAndEventResult'
+
+// common
+import { MobileCard } from 'common/components'
+import useDomains from 'common/hooks/useDomains'
+import { INTERNAL_ROUTES } from 'common/routes'
+
+dayjs.extend(relativeTime)
+
+interface Props {
+  result: Result
+}
+
+const ExtrinsicAndEventResultCard: FC<Props> = ({ result }) => {
+  const { selectedChain } = useDomains()
+  const blockDate = dayjs(result.timestamp).fromNow(true)
+
+  const body = [
+    { name: 'Block', value: result.blockHeight },
+    { name: 'Type', value: result.type },
+    { name: 'Action', value: result.action.split('.')[1].toUpperCase() },
+    { name: 'Time', value: `${blockDate} ago` },
+  ]
+
+  const link =
+    result.type === 'Extrinsic'
+      ? INTERNAL_ROUTES.extrinsics.id.page(selectedChain.urls.page, result.id)
+      : INTERNAL_ROUTES.events.id.page(selectedChain.urls.page, result.id)
+
+  return (
+    <MobileCard
+      id='extrinsic-list-extrinsic-mobile'
+      header={
+        <Link className='flex gap-2' to={link}>
+          <h3 className='font-medium text-[#241235] text-sm dark:text-white'>{result.id}</h3>
+        </Link>
+      }
+      body={body}
+    />
+  )
+}
+
+export default ExtrinsicAndEventResultCard

--- a/client/src/layout/components/ExtrinsicAndEventResult/index.tsx
+++ b/client/src/layout/components/ExtrinsicAndEventResult/index.tsx
@@ -1,0 +1,107 @@
+import { FC } from 'react'
+import { Link } from 'react-router-dom'
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+
+// common
+import { Column, Table } from 'common/components'
+import useDomains from 'common/hooks/useDomains'
+import { INTERNAL_ROUTES } from 'common/routes'
+import ExtrinsicAndEventResultCard from './ExtrinsicAndEventResultCard'
+
+dayjs.extend(relativeTime)
+
+export type Result = {
+  id: string
+  timestamp: string
+  action: string
+  blockHeight: number
+  indexInBlock: number
+  type: string
+}
+
+interface Props {
+  results: Result[]
+  isDesktop?: boolean
+}
+
+const ExtrinsicAndEventResultTable: FC<Props> = ({ results, isDesktop = false }) => {
+  const { selectedChain } = useDomains()
+  // methods
+  const generateColumns = (results: Result[]): Column[] => [
+    {
+      title: 'Id',
+      cells: results.map(({ id, indexInBlock, type }) => {
+        const link =
+          type === 'Extrinsic'
+            ? INTERNAL_ROUTES.extrinsics.id.page(selectedChain.urls.page, id)
+            : INTERNAL_ROUTES.events.id.page(selectedChain.urls.page, id)
+        return (
+          <Link key={`${id}-result-id-${indexInBlock}`} className='hover:text-[#DE67E4]' to={link}>
+            <div>{id}</div>
+          </Link>
+        )
+      }),
+    },
+    {
+      title: 'Block',
+      cells: results.map(({ blockHeight, indexInBlock, id }) => (
+        <Link
+          key={`${id}-result-block-${indexInBlock}`}
+          className='hover:text-[#DE67E4]'
+          to={INTERNAL_ROUTES.extrinsics.id.page(selectedChain.urls.page, id)}
+        >
+          <div>{blockHeight}</div>
+        </Link>
+      )),
+    },
+    {
+      title: 'Time',
+      cells: results.map(({ timestamp, id }, index) => {
+        const blockDate = dayjs(timestamp).fromNow(true)
+
+        return <div key={`${id}-result-time-${index}`}>{blockDate}</div>
+      }),
+    },
+    {
+      title: 'Action',
+      cells: results.map(({ action, id }, index) => (
+        <div key={`${id}-result-action-${index}`}>{action.split('.')[1].toUpperCase()}</div>
+      )),
+    },
+    {
+      title: 'Type',
+      cells: results.map(({ type, id }, index) => (
+        <div key={`${id}-result-type-${index}`}>{type}</div>
+      )),
+    },
+  ]
+
+  // constants
+  const columns = generateColumns(results)
+
+  return isDesktop ? (
+    <div className='w-full'>
+      <div className='rounded my-6'>
+        <Table
+          columns={columns}
+          emptyMessage='There are no extrinsics to show'
+          id='latest-extrinsics'
+          tableProps='bg-white rounded-[20px] dark:bg-gradient-to-r dark:from-[#4141B3] dark:via-[#6B5ACF] dark:to-[#896BD2] dark:border-none'
+          tableHeaderProps='border-b border-gray-200'
+        />
+      </div>
+    </div>
+  ) : (
+    <div className='w-full'>
+      {results.map((result, index) => (
+        <ExtrinsicAndEventResultCard
+          result={result}
+          key={`extrinsic-list-card-${result.id}-${index}`}
+        />
+      ))}
+    </div>
+  )
+}
+
+export default ExtrinsicAndEventResultTable

--- a/client/src/layout/components/SearchResult.tsx
+++ b/client/src/layout/components/SearchResult.tsx
@@ -1,10 +1,18 @@
+import { FC } from 'react'
+import { useLocation, useParams } from 'react-router-dom'
+
+// extrinsic
 import { ExtrinsicTable } from 'Extrinsic/components'
+
+// layout
+import { ExtrinsicAndEventResultTable } from 'layout/components'
+
+// common
 import { SearchBar } from 'common/components'
 import useMediaQuery from 'common/hooks/useMediaQuery'
-import { FC } from 'react'
-import { useLocation } from 'react-router-dom'
 
 const SearchResult: FC = () => {
+  const { type } = useParams<string>()
   const { state } = useLocation()
   const isDesktop = useMediaQuery('(min-width: 640px)')
 
@@ -17,7 +25,11 @@ const SearchResult: FC = () => {
         <div className='text-[#282929] text-base font-medium dark:text-white'>Search results</div>
       </div>
       <div className='w-full flex flex-col mt-5 sm:mt-0'>
-        <ExtrinsicTable extrinsics={state.extrinsics} isDesktop={isDesktop} />
+        {type === 'extrinsics' ? (
+          <ExtrinsicTable extrinsics={state.extrinsics} isDesktop={isDesktop} />
+        ) : (
+          <ExtrinsicAndEventResultTable results={state.results} isDesktop={isDesktop} />
+        )}
       </div>
     </div>
   )

--- a/client/src/layout/components/index.ts
+++ b/client/src/layout/components/index.ts
@@ -8,6 +8,7 @@ import HeaderBackground from 'layout/components/HeaderBackground'
 import HeaderDropdownMenu from 'layout/components/HeaderDropdownMenu'
 import HeaderChainDropdown from 'layout/components/HeaderChainDropdown'
 import MobileHeader from 'layout/components/MobileHeader'
+import ExtrinsicAndEventResultTable from 'layout/components/ExtrinsicAndEventResult'
 
 export {
   Layout,
@@ -20,4 +21,5 @@ export {
   HeaderDropdownMenu,
   HeaderChainDropdown,
   MobileHeader,
+  ExtrinsicAndEventResultTable,
 }


### PR DESCRIPTION
close #273 

If you search an event by Id, it can conflict with an extrinsic with the same id. This PR aims to fix that issue allowing a result page to show both results.

![image](https://user-images.githubusercontent.com/5139220/236969712-51e3f0f7-5cf7-4e1e-bca0-b5f79ac37497.png)
