### PR TITLE
add pipeline for evm-domain branch

### DIFF
--- a/.github/workflows/gh-container-image-evm.yml
+++ b/.github/workflows/gh-container-image-evm.yml
@@ -1,0 +1,49 @@
+name: Update container image
+
+on:   
+  push:
+    branches:
+      - evm-domain
+
+env:
+  PROCESSOR_NAME: ghcr.io/${{ github.repository_owner }}/blockexplorer-evm-processor:latest
+  API_SERVER_NAME: ghcr.io/${{ github.repository_owner }}/blockexplorer-evm-api-server:latest
+  HEALTH_CHECK_NAME: ghcr.io/${{ github.repository_owner }}/health-check:latest
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log into registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build processor image
+        run: docker build . --target processor -t squid-processor --tag $PROCESSOR_NAME
+        working-directory: squid-blockexplorer
+
+      - name: Build API server image
+        run: docker build . --target query-node -t graphql-server --tag $API_SERVER_NAME
+        working-directory: squid-blockexplorer
+      
+      - name: Build Health check image
+        run: docker build . --file Dockerfile --tag $HEALTH_CHECK_NAME
+        working-directory: health-check
+
+      - name: Push processor image
+        run: docker push $PROCESSOR_NAME
+
+      - name: Push API server image
+        run: docker push $API_SERVER_NAME
+      
+      - name: Push Health check image
+        run: docker push $HEALTH_CHECK_NAME


### PR DESCRIPTION
This PR creates a actions pipeline for the `evm-domain` branch and creates separate docker images for testing squid with evm compatibility.